### PR TITLE
Python 3.5 compatibility on Windows

### DIFF
--- a/natasha/data/__init__.py
+++ b/natasha/data/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 from __future__ import unicode_literals
-from yargy.compat import RUNNING_ON_PYTHON_2_VERSION
+from io import open
 
 import os
 
@@ -18,10 +18,8 @@ def maybe_strip_comment(line):
 
 def load_lines(filename):
     path = get_path(filename)
-    with open(path) as file:
+    with open(path, encoding='utf-8') as file:
         for line in file:
-            if RUNNING_ON_PYTHON_2_VERSION:
-                line = line.decode('utf-8')
             line = line.rstrip('\n')
             line = maybe_strip_comment(line)
             yield line


### PR DESCRIPTION
Исправлена проблема с кодировкой.
Она приводила к тому, что сущности имен не определялись на Python 3.5 на Windows 7, когда на Python 2.7 работало нормально.
Протестировано на Windows 7 для Python 2.7 и 3.5
