### PR TITLE
DatesExtractor: change YEAR_SHORT rule (prefer the 2000s for '00-'30)

### DIFF
--- a/natasha/grammars/date.py
+++ b/natasha/grammars/date.py
@@ -74,7 +74,7 @@ YEAR_SHORT = and_(
     gte(0),
     lte(99)
 ).interpretation(
-    Date.year.custom(lambda _: 1900 + int(_) if int(_) > 50 else 2000 + int(_))
+    Date.year.custom(lambda _: 1900 + int(_) if int(_) > 30 else 2000 + int(_))
 )
 
 DATE = or_(

--- a/natasha/grammars/date.py
+++ b/natasha/grammars/date.py
@@ -74,7 +74,7 @@ YEAR_SHORT = and_(
     gte(0),
     lte(99)
 ).interpretation(
-    Date.year.custom(lambda _: 1900 + int(_))
+    Date.year.custom(lambda _: 1900 + int(_) if int(_)>50 else 2000 + int(_))
 )
 
 DATE = or_(

--- a/natasha/grammars/date.py
+++ b/natasha/grammars/date.py
@@ -74,7 +74,7 @@ YEAR_SHORT = and_(
     gte(0),
     lte(99)
 ).interpretation(
-    Date.year.custom(lambda _: 1900 + int(_) if int(_)>50 else 2000 + int(_))
+    Date.year.custom(lambda _: 1900 + int(_) if int(_) > 50 else 2000 + int(_))
 )
 
 DATE = or_(


### PR DESCRIPTION
Сейчас по умолчанию для всех дат с указанием года из двух цифр выбирается 19-ый век, из-за чего даты типа "01.10.05" при извлечении автоматически преобразуются в Match(start=0, stop=8, fact=Date(year=1905, month=10, day=1).

Кажется, удобнее определять такие даты не в интервале 1900-1999, а в интервале 1931-2030.