### PR TITLE
fias types and others rules

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,0 +1,32 @@
+import json
+import sys
+import io
+
+# вызов из php:
+# $arg1 = escapeshellarg($addr);
+# $command = "python C:/projects/py/addr/natashapi.py $arg1";
+
+# Получаем аргументы
+line = sys.argv[1]
+
+from natasha import MorphVocab, AddrExtractor
+morph = MorphVocab()
+extractor = AddrExtractor(morph)
+
+match = extractor.find(line)
+response = {
+    'start': match.start,
+    'stop': match.stop,
+    'address': []
+}
+for part in match.fact.parts:
+    address_part = {
+        'value': part.value,
+        'type': part.type
+    }
+    response['address'].append(address_part)
+
+if sys.stdout.encoding != 'utf-8':
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+
+print(json.dumps(response, ensure_ascii=False))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 
-with open('README.md') as file:
+with open("README.md", encoding="utf-8") as file:
     description = file.read()
 
 


### PR DESCRIPTION
Most types are converted to types from the FIAS database, new rules for parsing parts of the address are added.
Added output of unparsed parts of the address.

Checked 37k bad addresses.
___________________
Большинство типов приведены к типам из базы данных ФИАС, добавлены новые правила для разбора частей адреса. 
Добавлен вывод неразобранных частей адреса.

Проверено 37к плохих адресов.
